### PR TITLE
Two small fixes

### DIFF
--- a/lib/design/text_theme.dart
+++ b/lib/design/text_theme.dart
@@ -88,6 +88,13 @@ class TextThemes {
     decoration: TextDecoration.underline,
   );
 
+  static final cancelText = TextStyle(
+    fontSize: 11.0,
+    fontWeight: FontWeight.w400,
+    color: Color.fromRGBO(247, 247, 255, 0.88),
+    letterSpacing: 0.06,
+  );
+
   static final discussionPostAuthorAnonDescriptor = TextStyle(
     fontSize: 12.0,
     fontWeight: FontWeight.w700,

--- a/lib/screens/discussion/overlay/participant_settings.dart
+++ b/lib/screens/discussion/overlay/participant_settings.dart
@@ -126,47 +126,47 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
             SizedBox(height: SpacingValues.mediumLarge),
             Container(height: 1.0, color: Color.fromRGBO(110, 111, 121, 0.6)),
             ListView(
-              padding: EdgeInsets.symmetric(vertical: SpacingValues.small),
-              shrinkWrap: true, 
-              children: [
-                ParticipantAnonymitySettingOption(
-                  height: 40.0,
-                  user: this.widget.me,
-                  anonymousGradient: this._selectedGradient,
-                  showAnonymous: false,
-                  participant: this.widget.meParticipant,
-                  isSelected: this._selectedIdx == 0,
-                  onSelected: () {
-                    setState(() {
-                      this._selectedIdx = 0;
-                    });
-                  },
-                  onEdit: () {
-                    this.setState(() {
-                      this._settingsState = _SettingsState.FLAIR_SELECT;
-                    });
-                  },
-                  showEditButton: this.widget.me.flairs != null &&
-                      this.widget.me.flairs.length > 0,
-                ),
-                ParticipantAnonymitySettingOption(
+                padding: EdgeInsets.symmetric(vertical: SpacingValues.small),
+                shrinkWrap: true,
+                children: [
+                  ParticipantAnonymitySettingOption(
                     height: 40.0,
                     user: this.widget.me,
                     anonymousGradient: this._selectedGradient,
-                    showAnonymous: true,
+                    showAnonymous: false,
                     participant: this.widget.meParticipant,
-                    isSelected: this._selectedIdx == 1,
+                    isSelected: this._selectedIdx == 0,
                     onSelected: () {
                       setState(() {
-                        this._selectedIdx = 1;
+                        this._selectedIdx = 0;
                       });
                     },
                     onEdit: () {
                       this.setState(() {
-                        this._settingsState = _SettingsState.GRADIENT_SELECT;
+                        this._settingsState = _SettingsState.FLAIR_SELECT;
                       });
-                    }),
-            ]),
+                    },
+                    showEditButton: this.widget.me.flairs != null &&
+                        this.widget.me.flairs.length > 0,
+                  ),
+                  ParticipantAnonymitySettingOption(
+                      height: 40.0,
+                      user: this.widget.me,
+                      anonymousGradient: this._selectedGradient,
+                      showAnonymous: true,
+                      participant: this.widget.meParticipant,
+                      isSelected: this._selectedIdx == 1,
+                      onSelected: () {
+                        setState(() {
+                          this._selectedIdx = 1;
+                        });
+                      },
+                      onEdit: () {
+                        this.setState(() {
+                          this._settingsState = _SettingsState.GRADIENT_SELECT;
+                        });
+                      }),
+                ]),
             Container(height: 1.0, color: Color.fromRGBO(110, 111, 121, 0.6)),
             Padding(
                 padding: EdgeInsets.symmetric(vertical: SpacingValues.medium),
@@ -179,7 +179,7 @@ class _ParticipantSettingsState extends State<ParticipantSettings> {
                           },
                           child: Text(
                             Intl.message('Cancel'),
-                            style: TextThemes.signInAngryNote,
+                            style: TextThemes.cancelText,
                           ))
                       : Container(width: 0, height: 0),
                   Row(

--- a/lib/widgets/profile_image/profile_image_with_gradient.dart
+++ b/lib/widgets/profile_image/profile_image_with_gradient.dart
@@ -60,16 +60,13 @@ class ProfileImageWithGradient extends StatelessWidget {
         height: this.height,
         decoration: BoxDecoration(
           gradient: gradient,
-          shape: this.isModerator ? BoxShape.circle : BoxShape.rectangle,
+          shape: BoxShape.circle,
           border: this.isModerator
               ? null
               : Border.all(
                   color: Colors.transparent,
                   width: 1.5,
                 ),
-          borderRadius: this.isModerator
-              ? null
-              : BorderRadius.all(Radius.circular(borderRadius)),
         ),
         child: profileImage,
       );


### PR DESCRIPTION
Making the input button a circular photo (#27) as well as removing the underline on `cancel` in the participant settings (#28)